### PR TITLE
Cambios de display name en Android y iOS

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="Cotizador"
+        android:label="Cotizador de Cuotas"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon">
         <activity

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Cotizador</string>
+	<string>Cotizador de Cuotas</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
# Cambios
- Se modificaron los archivos base para cambiar el display name de la aplicacion, la cual antes aparecia en minusculas